### PR TITLE
removed default on aws_account

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,6 @@ variable "include_resource" {
 variable "aws_account" {
   type        = string
   description = "The account name from the aws account shown in NewRelic."
-  default     = null
 }
 
 variable "tags" {


### PR DESCRIPTION
Integration won't work without setting aws_account -> set variable as mandatory.